### PR TITLE
Initial Interfaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 dist: precise
 php:
+  - '5.3'
   - '5.4'
   - '5.5'
   - '5.6'

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "phpunit/phpunit": "^4.8",
         "ptrofimov/xpmock": "^1.1",
-        "dhii/php-cs-fixer-config": "^0.1",
+        "dhii/php-cs-fixer-config": "dev-php-5.3",
         "codeclimate/php-test-reporter": "<=0.3.2"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^5.3 | ^7.0"
+        "php": "^5.3 | ^7.0",
+        "dhii/stringable-interface": "^0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,51 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "81fd0ad23604c339814afde8a281da25",
-    "packages": [],
+    "content-hash": "56fa5736d9cf81d8f40216177eb44701",
+    "packages": [
+        {
+            "name": "dhii/stringable-interface",
+            "version": "v0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dhii/stringable-interface.git",
+                "reference": "b6653905eef2ebf377749feb80a6d18abbe913ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dhii/stringable-interface/zipball/b6653905eef2ebf377749feb80a6d18abbe913ef",
+                "reference": "b6653905eef2ebf377749feb80a6d18abbe913ef",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 | ^7.0"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "<=0.3.2",
+                "dhii/php-cs-fixer-config": "dev-php-5.3",
+                "phpunit/phpunit": "^4.8",
+                "ptrofimov/xpmock": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dhii\\Util\\String\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dhii Team",
+                    "email": "development@dhii.co"
+                }
+            ],
+            "description": "Interoperability interface for objects that can be cast to string",
+            "time": "2017-01-23T15:08:20+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "codeclimate/php-test-reporter",

--- a/src/ArgumentCodeAwareInterface.php
+++ b/src/ArgumentCodeAwareInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Dhii\Exception;
+
+/**
+ * Something that can have an argument code retrieved from it.
+ *
+ * Can be useful for argument-related exceptions that need to provide more
+ * specific information about the argument.
+ *
+ * @since [*next-version*]
+ */
+interface ArgumentCodeAwareInterface
+{
+    /**
+     * Retrieves the argument code associated with this instance.
+     *
+     * @since [*next-version*]
+     *
+     * @return string|int The argument code. Something that identifies an argument
+     *                    in its scope.
+     */
+    public function getArgumentCode();
+}

--- a/src/InvalidArgumentExceptionInterface.php
+++ b/src/InvalidArgumentExceptionInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Dhii\Exception;
+
+/**
+ * Represents an exception that signals an invalid function argument.
+ *
+ * @since [*next-version*]
+ */
+interface InvalidArgumentExceptionInterface extends ThrowableInterface
+{
+    /**
+     * Retrieves the problematic argument.
+     *
+     * @since [*next-version*]
+     *
+     * @return mixed The argument value.
+     */
+    public function getArgument();
+}

--- a/src/ThrowableInterface.php
+++ b/src/ThrowableInterface.php
@@ -35,7 +35,7 @@ interface ThrowableInterface extends StringableInterface
     public function getCode();
 
     /**
-     * Retrieves the path to the file where this instance was thrown.
+     * Retrieves the path to the file where this instance was created.
      *
      * @since [*next-version*]
      *
@@ -44,7 +44,7 @@ interface ThrowableInterface extends StringableInterface
     public function getFile();
 
     /**
-     * Retrieves the number of the line where the exception was thrown.
+     * Retrieves the number of the line where the exception was created.
      *
      * @since [*next-version*]
      *

--- a/src/ThrowableInterface.php
+++ b/src/ThrowableInterface.php
@@ -3,6 +3,7 @@
 namespace Dhii\Exception;
 
 use Exception as RootException;
+use Dhii\Util\String\StringableInterface;
 
 /**
  * Formalizes the interface of exceptions and errors.
@@ -13,19 +14,76 @@ use Exception as RootException;
  *
  * @since [*next-version*]
  */
-interface ThrowableInterface
+interface ThrowableInterface extends StringableInterface
 {
     /**
+     * Retrieves the message.
+     *
      * @since [*next-version*]
      *
-     * @return string|Stringable
+     * @return string The message.
      */
-    public getMessage();
-abstract public int getCode();
-abstract public string getFile();
-abstract public int getLine();
-abstract public array getTrace();
-abstract public string getTraceAsString();
-abstract public getPrevious();
-abstract public string __toString();
+    public function getMessage();
+
+    /**
+     * Retrieves the code.
+     *
+     * @since [*next-version*]
+     *
+     * @return int The code.
+     */
+    public function getCode();
+
+    /**
+     * Retrieves the path to the file where this instance was thrown.
+     *
+     * @since [*next-version*]
+     *
+     * @return string Path to the file.
+     */
+    public function getFile();
+
+    /**
+     * Retrieves the number of the line where the exception was thrown.
+     *
+     * @since [*next-version*]
+     *
+     * @return int The line number.
+     */
+    public function getLine();
+
+    /**
+     * Retrieves the backtrace data.
+     *
+     * @since [*next-version*]
+     *
+     * @return array[] Frames of the backtrace, in the same format as
+     *                 returned by {@see debug_backtrace()}.
+     */
+    public function getTrace();
+
+    /**
+     * Retrieves the trace in human-readable string format.
+     *
+     * @since [*next-version*]
+     *
+     * @return string The string representation of backtrace steps.
+     */
+    public function getTraceAsString();
+
+    /**
+     * Retrieves the previous, inner exception for chaining.
+     *
+     * @since [*next-version*]
+     *
+     * @return RootException|null The inner exception, if any.
+     */
+    public function getPrevious();
+
+    /**
+     * Retrieves the human-readable representation of the error.
+     *
+     * @since [*next-version*]
+     */
+    public function __toString();
 }

--- a/test/unit/ArgumentCodeAwareInterfaceTest.php
+++ b/test/unit/ArgumentCodeAwareInterfaceTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Dhii\Exception\UnitTest;
+
+use Xpmock\TestCase;
+
+/**
+ * Tests {@see \Dhii\Exception\ArgumentCodeAwareInterface}.
+ *
+ * @since [*next-version*]
+ */
+class ArgumentCodeAwareInterfaceTest extends TestCase
+{
+    /**
+     * The name of the test subject.
+     *
+     * @since [*next-version*]
+     */
+    const TEST_SUBJECT_CLASSNAME = 'Dhii\Exception\ArgumentCodeAwareInterface';
+
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @since [*next-version*]
+     *
+     * @return \Dhii\Exception\ArgumentCodeAwareInterface
+     */
+    public function createInstance()
+    {
+        $mock = $this->mock(static::TEST_SUBJECT_CLASSNAME)
+                ->getArgumentCode()
+                ->new();
+
+        return $mock;
+    }
+
+    /**
+     * Tests whether a valid instance of the test subject can be created.
+     *
+     * @since [*next-version*]
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createInstance();
+
+        $this->assertInstanceOf(static::TEST_SUBJECT_CLASSNAME, $subject, 'A valid instance of the subject could not be created');
+    }
+}

--- a/test/unit/InvalidArgumentExceptionInterfaceTest.php
+++ b/test/unit/InvalidArgumentExceptionInterfaceTest.php
@@ -16,7 +16,7 @@ class InvalidArgumentExceptionInterfaceTest extends TestCase
      *
      * @since [*next-version*]
      */
-    const TEST_SUBJECT_CLASSNAME = 'Dhii\\Exception\\InvalidArgumentExceptionInterface';
+    const TEST_SUBJECT_CLASSNAME = 'Dhii\Exception\InvalidArgumentExceptionInterface';
 
     /**
      * Creates a new instance of the test subject.
@@ -51,8 +51,6 @@ class InvalidArgumentExceptionInterfaceTest extends TestCase
     {
         $subject = $this->createInstance();
 
-        $this->assertInstanceOf(
-            static::TEST_SUBJECT_CLASSNAME, $subject, 'Subject is not a valid instance.'
-        );
+        $this->assertInstanceOf(static::TEST_SUBJECT_CLASSNAME, $subject, 'A valid instance of the subject could not be created');
     }
 }

--- a/test/unit/InvalidArgumentExceptionInterfaceTest.php
+++ b/test/unit/InvalidArgumentExceptionInterfaceTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Dhii\Exception\UnitTest;
+
+use Xpmock\TestCase;
+
+/**
+ * Tests {@see \Dhii\Exception\InvalidArgumentExceptionInterface}.
+ *
+ * @since [*next-version*]
+ */
+class InvalidArgumentExceptionInterfaceTest extends TestCase
+{
+    /**
+     * The name of the test subject.
+     *
+     * @since [*next-version*]
+     */
+    const TEST_SUBJECT_CLASSNAME = 'Dhii\\Exception\\InvalidArgumentExceptionInterface';
+
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @since [*next-version*]
+     *
+     * @return \Dhii\Exception\InvalidArgumentExceptionInterface
+     */
+    public function createInstance()
+    {
+        $mock = $this->mock(static::TEST_SUBJECT_CLASSNAME)
+                ->getMessage()
+                ->getCode()
+                ->getFile()
+                ->getLine()
+                ->getTrace()
+                ->getTraceAsString()
+                ->getPrevious()
+                ->__toString()
+                ->getArgument()
+                ->new();
+
+        return $mock;
+    }
+
+    /**
+     * Tests whether a valid instance of the test subject can be created.
+     *
+     * @since [*next-version*]
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createInstance();
+
+        $this->assertInstanceOf(
+            static::TEST_SUBJECT_CLASSNAME, $subject, 'Subject is not a valid instance.'
+        );
+    }
+}

--- a/test/unit/ThrowableInterfaceTest.php
+++ b/test/unit/ThrowableInterfaceTest.php
@@ -16,7 +16,7 @@ class ThrowableInterfaceTest extends TestCase
      *
      * @since [*next-version*]
      */
-    const TEST_SUBJECT_CLASSNAME = 'Dhii\\Exception\\ThrowableInterface';
+    const TEST_SUBJECT_CLASSNAME = 'Dhii\Exception\ThrowableInterface';
 
     /**
      * Creates a new instance of the test subject.
@@ -50,8 +50,6 @@ class ThrowableInterfaceTest extends TestCase
     {
         $subject = $this->createInstance();
 
-        $this->assertInstanceOf(
-            static::TEST_SUBJECT_CLASSNAME, $subject, 'Subject is not a valid instance.'
-        );
+        $this->assertInstanceOf(static::TEST_SUBJECT_CLASSNAME, $subject, 'A valid instance of the subject could not be created');
     }
 }

--- a/test/unit/ThrowableInterfaceTest.php
+++ b/test/unit/ThrowableInterfaceTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Dhii\Exception\UnitTest;
+
+use Xpmock\TestCase;
+
+/**
+ * Tests {@see \Dhii\Exception\ThrowableInterface}.
+ *
+ * @since [*next-version*]
+ */
+class ThrowableInterfaceTest extends TestCase
+{
+    /**
+     * The name of the test subject.
+     *
+     * @since [*next-version*]
+     */
+    const TEST_SUBJECT_CLASSNAME = 'Dhii\\Exception\\ThrowableInterface';
+
+    /**
+     * Creates a new instance of the test subject.
+     *
+     * @since [*next-version*]
+     *
+     * @return \Dhii\Exception\ThrowableInterface
+     */
+    public function createInstance()
+    {
+        $mock = $this->mock(static::TEST_SUBJECT_CLASSNAME)
+                ->getMessage()
+                ->getCode()
+                ->getFile()
+                ->getLine()
+                ->getTrace()
+                ->getTraceAsString()
+                ->getPrevious()
+                ->__toString()
+                ->new();
+
+        return $mock;
+    }
+
+    /**
+     * Tests whether a valid instance of the test subject can be created.
+     *
+     * @since [*next-version*]
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createInstance();
+
+        $this->assertInstanceOf(
+            static::TEST_SUBJECT_CLASSNAME, $subject, 'Subject is not a valid instance.'
+        );
+    }
+}


### PR DESCRIPTION
Generic `ThrowableInterface` represents any kind of exception and is useful before PHP 7.0. `InvalidArgumentExceptionInterface` extends that to expose the invalid argument's value.